### PR TITLE
Updated external collaborator permissions

### DIFF
--- a/terraform/mojspeakr.tf
+++ b/terraform/mojspeakr.tf
@@ -5,22 +5,13 @@ module "mojspeakr" {
     {
       github_user  = "dipad-fran-bryden"
       permission   = "admin"
-      name         = "tbc"
-      email        = "tbc"
-      org          = "tbc"
-      reason       = "tbc"
+      name         = "Francesca Bryden"
+      email        = "francesca.bryden@dft.gov.uk"
+      org          = "Department for Transport"
+      reason       = "Creator and maintainer of package"
       added_by     = "Nick Walters nick.walters@digital.justice.gov.uk"
-      review_after = "2023-06-13"
+      review_after = "2024-06-13"
     },
-    {
-      github_user  = "brydenfrancesca"
-      permission   = "admin"
-      name         = "tbc"
-      email        = "tbc"
-      org          = "tbc"
-      reason       = "tbc"
-      added_by     = "Nick Walters nick.walters@digital.justice.gov.uk"
-      review_after = "2023-06-13"
-    },
+
   ]
 }


### PR DESCRIPTION
As per [mojspeakr issue 35](https://github.com/moj-analytical-services/mojspeakr/issues/35), have cleaned external collaborator permissions for this repo:

* Removed permissions for my personal account
* Added permissions for a further 12 months to my work account and completed missing deets