### PR TITLE
Replace GitHub secret name with new FG-PAT name

### DIFF
--- a/.github/workflows/check-collaborators-username.yml
+++ b/.github/workflows/check-collaborators-username.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Do check
         run: ruby bin/check-collaborators-usernames.rb
         env:
-          OPS_BOT_TOKEN: ${{ secrets.OPS_BOT_TOKEN }}
+          OPS_BOT_TOKEN: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
           LOG_LEVEL: "info"

--- a/.github/workflows/check-fork-status.yml
+++ b/.github/workflows/check-fork-status.yml
@@ -15,4 +15,4 @@ jobs:
       - run: python3 scripts/check_fork_status.py
         env:
           PR_DATA: ${{ toJson(github.event.pull_request) }}
-          TOKEN: ${{ secrets.OPS_BOT_TOKEN }}
+          TOKEN: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}

--- a/.github/workflows/close-expired-issues.yml
+++ b/.github/workflows/close-expired-issues.yml
@@ -19,5 +19,5 @@ jobs:
       - run: bundle install
       - run: bin/close-expired-issues.rb
         env:
-          OPS_BOT_TOKEN: ${{ secrets.OPS_BOT_TOKEN }}
+          OPS_BOT_TOKEN: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
           LOG_LEVEL: "info"

--- a/.github/workflows/create-pr-from-issue.yml
+++ b/.github/workflows/create-pr-from-issue.yml
@@ -23,7 +23,7 @@ jobs:
         run: ruby bin/create-pr-from-issue.rb
         env:
           ISSUE: ${{ toJson(github.event.issue) }}
-          OPS_BOT_TOKEN: ${{ secrets.OPS_BOT_TOKEN }}
+          OPS_BOT_TOKEN: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
           REALLY_POST_TO_GH: ${{ secrets.POST_TO_GH }}
           NOTIFY_PROD_TOKEN: ${{ secrets.NOTIFY_PROD_TOKEN }}
           NOTIFY_TEST_TOKEN: ${{ secrets.NOTIFY_TEST_TOKEN }}

--- a/.github/workflows/delete-expired-invites.yml
+++ b/.github/workflows/delete-expired-invites.yml
@@ -20,5 +20,5 @@ jobs:
       - run: bundle install
       - run: bin/delete-expired-invites.rb
         env:
-          OPS_BOT_TOKEN: ${{ secrets.OPS_BOT_TOKEN }}
+          OPS_BOT_TOKEN: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
           LOG_LEVEL: "info"

--- a/.github/workflows/outside-collaborators-check.yaml
+++ b/.github/workflows/outside-collaborators-check.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Check the outside collaborators
         run: bin/outside-collaborators.rb
         env:
-          OPS_BOT_TOKEN: ${{ secrets.OPS_BOT_TOKEN }}
+          OPS_BOT_TOKEN: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
           NOTIFY_PROD_TOKEN: ${{ secrets.NOTIFY_PROD_TOKEN }}
           NOTIFY_TEST_TOKEN: ${{ secrets.NOTIFY_TEST_TOKEN }}
           REALLY_POST_TO_SLACK: ${{ secrets.POST_TO_SLACK }}

--- a/.github/workflows/repository-check.yaml
+++ b/.github/workflows/repository-check.yaml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: main
-      - run: bash scripts/repository-check.sh ${{ github.event.inputs.github_user }} ${{ secrets.OPS_BOT_TOKEN }}
+      - run: bash scripts/repository-check.sh ${{ github.event.inputs.github_user }} ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}

--- a/.github/workflows/targeted-terraform-plan.yml
+++ b/.github/workflows/targeted-terraform-plan.yml
@@ -9,7 +9,7 @@ env:
   TERRAFORM: terraform
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  TF_VAR_github_token: ${{ secrets.OPS_BOT_TOKEN }}
+  TF_VAR_github_token: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
   TF_IN_AUTOMATION: true
 
 jobs:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -11,7 +11,7 @@ env:
   TERRAFORM: terraform
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  TF_VAR_github_token: ${{ secrets.OPS_BOT_TOKEN }}
+  TF_VAR_github_token: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
   TF_IN_AUTOMATION: true
 
 jobs:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -10,7 +10,7 @@ env:
   TERRAFORM: terraform
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  TF_VAR_github_token: ${{ secrets.OPS_BOT_TOKEN }}
+  TF_VAR_github_token: ${{ secrets.MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT }}
   TF_IN_AUTOMATION: true
 
 jobs:


### PR DESCRIPTION
## 👀 Purpose

- Reducing the number of classic token in use and to adhere to POLP.

## ♻️ What's changed

- ✨ A new Fine-grained PAT added to the repo secrets; MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT
- ♻️ Replaced instances of OPS_BOT_TOKEN with MOJAS_COLLABORATORS_GENERAL_ADMIN_BOT_PAT

## 📝 Notes

-